### PR TITLE
Fix issue in shell32.ExtractAssociatedIcon call that could result in a buffer overflow under certain conditions

### DIFF
--- a/libcommon/ProcessIconImageList.h
+++ b/libcommon/ProcessIconImageList.h
@@ -28,9 +28,16 @@ class ProcessIconImageList
 		}
 		ICON_DEBUG_PRINT(L"Extracting icon for %s", pwszFilename);
 		WORD wIndex = 0;
+
 		// make a copy of pwszFilename because the pwszIconPath param of ExtractAssociatedIcon is non-const.
 		//  On return, pwszIconPath is filled with the pathname to the file containing the selected icon
-		//  which may be different than the pathname passed in. Therefore, minimum size should be MAX_PATH.
+		//  which may be different than the pathname passed in. Therefore, minimum size should be MAX_PATH.				
+
+		// abort if pwszFilename exceeds our max size
+		if (wcslen(pwszFilename) >= LibcommonWindowsConsts::EFFECTIVE_WINDOWS_MAX_PATH)
+		{
+			return NULL;
+		}
 		WCHAR wszBuffer[LibcommonWindowsConsts::EFFECTIVE_WINDOWS_MAX_PATH] = { 0 };
 		wcscpy_s(wszBuffer, _countof(wszBuffer), pwszFilename);
 		return ExtractAssociatedIcon(GetModuleHandle(nullptr), wszBuffer, &wIndex);

--- a/libcommon/ProcessIconImageList.h
+++ b/libcommon/ProcessIconImageList.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <set>
 #include <mutex>
+#include "WindowsConsts.h"
 #include "DebugOutToggles.h"
 
 // manages a process icon imagelist for a listview
@@ -27,10 +28,13 @@ class ProcessIconImageList
 		}
 		ICON_DEBUG_PRINT(L"Extracting icon for %s", pwszFilename);
 		WORD wIndex = 0;
-		// we must make a copy of the filename because ExtractAssociatedIcon can modify it
-		WCHAR wszBuffer[MAX_PATH] = { 0 };
-		wcscpy_s(wszBuffer, MAX_PATH, pwszFilename);
-		return ExtractAssociatedIcon(GetModuleHandle(NULL), wszBuffer, &wIndex);
+		// make a copy of pwszFilename because the pwszIconPath param of ExtractAssociatedIcon is non-const.
+		//  On return, pwszIconPath is filled with the pathname to the file containing the selected icon
+		//  which may be different than the pathname passed in. Therefore, minimum size should be MAX_PATH.
+
+		WCHAR wszBuffer[LibcommonWindowsConsts::EFFECTIVE_WINDOWS_MAX_PATH] = { 0 };
+		wcscpy_s(wszBuffer, _countof(wszBuffer), pwszFilename);
+		return ExtractAssociatedIcon(GetModuleHandle(nullptr), wszBuffer, &wIndex);
 	}
 public:
 	ProcessIconImageList(const HICON hSuppliedFailsafeIcon = NULL)

--- a/libcommon/ProcessIconImageList.h
+++ b/libcommon/ProcessIconImageList.h
@@ -27,15 +27,18 @@ class ProcessIconImageList
 		}
 		ICON_DEBUG_PRINT(L"Extracting icon for %s", pwszFilename);
 		WORD wIndex = 0;
-		return ExtractAssociatedIcon(GetModuleHandle(NULL), const_cast<LPWSTR>(pwszFilename), &wIndex);
+		// we must make a copy of the filename because ExtractAssociatedIcon can modify it
+		WCHAR wszBuffer[MAX_PATH] = { 0 };
+		wcscpy_s(wszBuffer, MAX_PATH, pwszFilename);
+		return ExtractAssociatedIcon(GetModuleHandle(NULL), wszBuffer, &wIndex);
 	}
 public:
 	ProcessIconImageList(const HICON hSuppliedFailsafeIcon = NULL)
 	{
 		// create imagelist and init with failsafe icon, for when an app icon is not avail
 		hImageList = ImageList_Create(16, 16, ILC_COLOR32, 1, _Imagelist_MaxSize);
-		_ASSERT(hImageList);		
-		
+		_ASSERT(hImageList);
+
 		// if failsafe icon was not supplied, load one from disk - svchost.exe
 		HICON hSelectedFailsafeIcon = hSuppliedFailsafeIcon;
 		if (NULL == hSelectedFailsafeIcon)
@@ -144,12 +147,12 @@ public:
 
 		int nImageIndex = mapFilenameToImgIdx[csFile];
 		if (--mapImgIdxToRefCount[nImageIndex] == 0)
-		{			
-			ICON_DEBUG_PRINT(L"Reference count for %d %s now 0. Removing!", nImageIndex, csFile);			
+		{
+			ICON_DEBUG_PRINT(L"Reference count for %d %s now 0. Removing!", nImageIndex, csFile);
 			_ASSERT(nImageIndex != nFailsafeIconIndex);
-			
+
 			ImageList_Remove(hImageList, nImageIndex);
-			
+
 			mapFilenameToImgIdx.erase(csFile);
 
 			// removing an icon from the imagelist changes the higher indices, so adjust prior refs

--- a/libcommon/ProcessIconImageList.h
+++ b/libcommon/ProcessIconImageList.h
@@ -31,7 +31,6 @@ class ProcessIconImageList
 		// make a copy of pwszFilename because the pwszIconPath param of ExtractAssociatedIcon is non-const.
 		//  On return, pwszIconPath is filled with the pathname to the file containing the selected icon
 		//  which may be different than the pathname passed in. Therefore, minimum size should be MAX_PATH.
-
 		WCHAR wszBuffer[LibcommonWindowsConsts::EFFECTIVE_WINDOWS_MAX_PATH] = { 0 };
 		wcscpy_s(wszBuffer, _countof(wszBuffer), pwszFilename);
 		return ExtractAssociatedIcon(GetModuleHandle(nullptr), wszBuffer, &wIndex);

--- a/libcommon/WindowsConsts.h
+++ b/libcommon/WindowsConsts.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace LibcommonWindowsConsts
+{
+	// https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+	static const unsigned long EFFECTIVE_WINDOWS_MAX_PATH = 32 * 1024;
+};

--- a/libcommon/libcommon.vcxproj
+++ b/libcommon/libcommon.vcxproj
@@ -180,6 +180,7 @@
     <ClInclude Include="win32-darkmode\win32-darkmode\ListViewUtil.h" />
     <ClInclude Include="win32-darkmode\win32-darkmode\UAHMenuBar.h" />
     <ClInclude Include="win32-darkmode\win32-darkmode\win32-darkmode.h" />
+    <ClInclude Include="WindowsConsts.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="bitOperations.cpp" />


### PR DESCRIPTION
This fixes a potential buffer overflow in the call to [ExtractAssociatedIcon](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-extractassociatediconw). One of its parameters, pszIconPath, is a pointer to a non-const buffer holding the pathname to retrieve the icon for. We (I) never paid much attention to it being non-const, and neither have most programmers, as virtually every example of this API, and its sibling ExtractAssociatedIconEx, on the internet is wrong in the same way.

Turns out, it's non-const for a reason: ExtractAssociatedIcon can choose an icon held in a different module than pszIconPath specifies, and in that case, it will will fill the buffer pointed to by pszIconPath with the pathname of the module it actually extracted the icon from.

For files on mapped network drives, an icon is selected from shell32.dll instead of the target executable, so the buffer is filled with shell32's pathname. If that pathname exceeded the original string length, a buffer overflow occurred.

Ultimately, it's poor API design by Microsoft, even at the time it was introduced in XP. The parameter use would have been clarified and buffer overflow prevented if the API accepted a now standard buffer size parameter. Instead, the minimum required size is presumably MAX_PATH, though the documentation doesn't specify such.